### PR TITLE
discard query params before parsing url

### DIFF
--- a/yext-sites-scripts/ssr/serverRenderRoute.ts
+++ b/yext-sites-scripts/ssr/serverRenderRoute.ts
@@ -18,7 +18,7 @@ type Props = {
 export const serverRenderRoute =
   ({ vite, i18n, dynamicGenerateData }: Props): RequestHandler =>
     async (req, res, next) => {
-      const url = req.originalUrl;
+      const url = req.baseUrl;
 
       const { feature, entityId } = urlToFeature(url);
       const templateFilename = await featureToTemplate(vite, feature);


### PR DESCRIPTION
Currently a url like `index/loc6?param=value` will error because it uses the full url to try and match against the feature/entityId.  